### PR TITLE
PR: Support execution context parameters and querying all orchestrations

### DIFF
--- a/src/Aqovia.DurableFunctions.Testing/Aqovia.DurableFunctions.Testing.csproj
+++ b/src/Aqovia.DurableFunctions.Testing/Aqovia.DurableFunctions.Testing.csproj
@@ -22,11 +22,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.14.0" />
 		<PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
-		<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
-		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.11.1" />
-		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
+		<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
+		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.8.1" />
+		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
 		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
 		<PackageReference Include="Microsoft.Azure.DurableTask.Emulator" Version="2.5.4" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.19" />

--- a/src/Aqovia.DurableFunctions.Testing/Aqovia.DurableFunctions.Testing.csproj
+++ b/src/Aqovia.DurableFunctions.Testing/Aqovia.DurableFunctions.Testing.csproj
@@ -22,10 +22,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.14.0" />
 		<PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.2" />
-		<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.18" />
-		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.5.0" />
-		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
+		<PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
+		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.11.1" />
+		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
 		<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
 		<PackageReference Include="Microsoft.Azure.DurableTask.Emulator" Version="2.5.4" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.19" />

--- a/src/Aqovia.DurableFunctions.Testing/DurableFuncV2Helper.cs
+++ b/src/Aqovia.DurableFunctions.Testing/DurableFuncV2Helper.cs
@@ -162,6 +162,7 @@ namespace Aqovia.DurableFunctions.Testing
                     {
                         webJobsBuilder.Services.AddSingleton<IDurabilityProviderFactory, EmulatorDurabilityProviderFactory>();
                         webJobsBuilder.AddHttp();
+                        webJobsBuilder.AddExecutionContextBinding();
                         webJobsBuilder.AddDurableTask(options);
                         webJobsBuilder.AddAzureStorage();
                     })

--- a/src/Aqovia.DurableFunctions.Testing/TestJobHostWrapper.cs
+++ b/src/Aqovia.DurableFunctions.Testing/TestJobHostWrapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -6,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using DurableTask.Core;
+using DurableTask.Core.Query;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.DurableTask;
 using Microsoft.Extensions.DependencyInjection;
@@ -175,6 +177,20 @@ namespace Aqovia.DurableFunctions.Testing
         public TestLogger GetLoggerByCategoryName(string categoryName)
         {
             return _loggerProvider.CreatedLoggers.SingleOrDefault(l => l.Category == categoryName);
+        }
+
+        /// <summary>
+        /// Fetches a read-only list of OrchestrationState objects, optionally filtered by the provided query parameter.
+        /// This method is especially useful when the instance ID(s) of the target orchestration(s) are unknown.
+        /// Omitting the query argument will fetch all OrchestrationStates
+        /// </summary>
+        /// <param name="query">An optional parameter of type OrchestrationQuery to filter the results.</param>
+        /// <returns>Returns a read-only collection containing OrchestrationState objects.</returns>
+        public async Task<IReadOnlyCollection<OrchestrationState>> GetOrchestrationStatesAsync(OrchestrationQuery query = null)
+        {
+            return (await ((IOrchestrationServiceQueryClient)_durabilityProvider).GetOrchestrationWithQueryAsync(
+                query ?? new OrchestrationQuery(),
+                CancellationToken.None)).OrchestrationState;
         }
 
         protected virtual void Dispose(bool disposing)

--- a/test/Aqovia.DurableFunctions.Testing.EndToEndTests/SampleFunctionAppEndToEndTests.cs
+++ b/test/Aqovia.DurableFunctions.Testing.EndToEndTests/SampleFunctionAppEndToEndTests.cs
@@ -9,7 +9,6 @@ using SampleFunctionApp;
 using SampleFunctionApp.Models;
 using SampleFunctionApp.Services;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using DurableTask.Core.Query;
 using Xunit.Abstractions;

--- a/test/Aqovia.DurableFunctions.Testing.EndToEndTests/SampleFunctionAppEndToEndTests.cs
+++ b/test/Aqovia.DurableFunctions.Testing.EndToEndTests/SampleFunctionAppEndToEndTests.cs
@@ -81,7 +81,7 @@ namespace Aqovia.DurableFunctions.Testing.EndToEndTests
                 logger.Should().NotBeNull();
 
                 var expectedLogMessages = new[] {
-                    ( LogLevel.Information, "C# HTTP trigger function processed a request." ),
+                    ( LogLevel.Information, "C# HTTP trigger function 'HttpTriggerFunction' processed a request." ),
                     ( LogLevel.Information, $"Started orchestration with ID = '{instanceId}'.")
                 };
 

--- a/test/SampleFunctionApp/SampleFunctions.cs
+++ b/test/SampleFunctionApp/SampleFunctions.cs
@@ -47,10 +47,13 @@ namespace SampleFunctionApp
 
         [FunctionName("HttpTriggerFunction")]
         public async Task<IActionResult> HttpTriggerFunction(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequest req, [DurableClient] IDurableOrchestrationClient starter)
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]
+            HttpRequest req,
+            ExecutionContext context,
+            [DurableClient] IDurableOrchestrationClient starter)
         {
-            _logger.LogInformation("C# HTTP trigger function processed a request.");
-
+            _logger.LogInformation($"C# HTTP trigger function '{context.FunctionName}' processed a request.");
+            
             string data = req.Query["data"];
             string id = req.Query["id"];
 


### PR DESCRIPTION
bump:minor

This PR addresses two limitations with the `DurableFunctions.Testing` library:
1] The library does not yet support functions which include an `ExecutionContext` parameter
E.g.
```
[FunctionName("ServiceApi_ActivateService")]
public async Task<IActionResult> _ActivateService(
    [HttpTrigger(AuthorizationLevel.Anonymous, "Post", Route = "services/activate")]HttpRequest req, 
    ExecutionContext context, 
    [DurableClient] IDurableClient client) {
...
}
```
  To address this this PR adds `AddExecutionContextBinding` to the `ConfigureWebJobs` call.
2] The library assumes an orchestrator instance Id is known by the test. This is not guaranteed. 
    This PR exposes `IOrchestrationServiceQueryClient.GetOrchestrationWithQueryAsync` via a new method named `GetOrchestrationStatesAsync`. This method can be used by the API consumer to fetch all orchestrations or filter them by query.
 E.g.
```
var orchestrations = await host.GetOrchestrationStatesAsync();
orchestrations.Count.Should().Be(1);

instanceId = orchestrations.Single().OrchestrationInstance.InstanceId;
```