### PR TITLE
Publish version 3.1.0

### DIFF
--- a/src/Aqovia.DurableFunctions.Testing/TestJobHostWrapper.cs
+++ b/src/Aqovia.DurableFunctions.Testing/TestJobHostWrapper.cs
@@ -14,7 +14,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit.Abstractions;
 
-
 namespace Aqovia.DurableFunctions.Testing
 {
     public class TestJobHostWrapper : IDisposable


### PR DESCRIPTION
bump: minor

This PR intends to address an incorrect version increment.
Version 1.0.0 was incorrectly tagged as the latest, which caused the last successful release to publish as 1.1.0. It should have been 3.1.0.
3.0.0 has since been tagged as latest. Completing this PR should result in 3.1.0, after which release descriptions will be updated accordingly.