### PR TITLE
Publish version 3.0.2

### DIFF
--- a/src/Aqovia.DurableFunctions.Testing/TestJobHostWrapper.cs
+++ b/src/Aqovia.DurableFunctions.Testing/TestJobHostWrapper.cs
@@ -1,17 +1,16 @@
-﻿using System;
+﻿using DurableTask.Core;
+using DurableTask.Core.Query;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.DurableTask;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-
-using DurableTask.Core;
-using DurableTask.Core.Query;
-using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Extensions.DurableTask;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Xunit.Abstractions;
 
 namespace Aqovia.DurableFunctions.Testing


### PR DESCRIPTION
bump: patch

This PR intends to address an incorrect version increment.
Version 1.1.0 was incorrectly tagged as the latest, which caused the last successful release to publish as 1.2.0. It should have been 3.1.0.
This branch has tagged a commit tagged with v3.0.1. Completing this PR (with bump: patch) should result in 3.0.2, after which release descriptions will be updated accordingly.